### PR TITLE
[BUGFIX] Kissanime episode identification

### DIFF
--- a/src/pages/Kissanime/main.ts
+++ b/src/pages/Kissanime/main.ts
@@ -27,7 +27,7 @@ export const Kissanime: pageInterface = {
         }
         temp = episodePart.match(/\d{3}/);
         if(temp === null){
-            temp = episodePart.match(/\d{2,}\-/);
+            temp = episodePart.match(/\d{2,}\-?/);
             if(temp === null){
                 episodePart = 1;
             }else{


### PR DESCRIPTION
Fixes issue #188 
This should only change the behavior when episode detection fails, else it will behave identically to the old system. This is better than the solution I asked about on discord.