### PR TITLE
AnimeZone fix

### DIFF
--- a/src/pages/pageUrls.js
+++ b/src/pages/pageUrls.js
@@ -322,7 +322,7 @@ module.exports = {
   AnimeZone: {
     match: [
       '*://www.animezone.pl/odcinki/*',
-      '*://www.animezone.pl/odcinek/*'
+      '*://www.animezone.pl/anime/*'
     ]
   },
   AnimeOdcinki: {

--- a/test/headless/test.js
+++ b/test/headless/test.js
@@ -1328,14 +1328,14 @@ var testsArray = [
           sync: true,
           title: 'Cop Craft',
           identifier: 'cop-craft',
-          overviewUrl: 'https://www.animezone.pl/odcinki/cop-craft',
+          overviewUrl: 'https://www.animezone.pl/anime/cop-craft',
           nextEpUrl: 'https://www.animezone.pl/odcinek/cop-craft/2',
           episode: 1,
           uiSelector: false,
         }
       },
       {
-        url: 'https://www.animezone.pl/odcinki/cop-craft',
+        url: 'https://www.animezone.pl/anime/cop-craft',
         expected: {
           sync: false,
           title: 'Cop Craft',


### PR DESCRIPTION
Recently, AnimeZone changed some urls. The site currently requires login to view content (episode mirror list).